### PR TITLE
feat: deep equal

### DIFF
--- a/src/Component.ts
+++ b/src/Component.ts
@@ -1,3 +1,5 @@
+import { deepEqual } from "./utils/compare";
+
 export interface PropsType {}
 export interface StateType {}
 
@@ -45,7 +47,7 @@ export default class Component<P extends PropsType, S extends StateType> {
 
   setState(newState: Partial<S>) {
     const nextState = { ...this.state, ...newState };
-    if (JSON.stringify(this.state) === JSON.stringify(nextState)) {
+    if (deepEqual(this.state, nextState)) {
       return;
     }
     this.state = nextState;

--- a/src/utils/compare.ts
+++ b/src/utils/compare.ts
@@ -1,0 +1,33 @@
+export function deepEqual(obj1: any, obj2: any): boolean {
+  // 일반적인 경우에 대한 빠른 비교
+  if (obj1 === obj2) {
+    return true;
+  }
+
+  // null 또는 다른 유형을 비교하는 경우
+  if (
+    typeof obj1 !== "object" ||
+    obj1 === null ||
+    typeof obj2 !== "object" ||
+    obj2 === null
+  ) {
+    return false;
+  }
+
+  const keys1 = Object.keys(obj1);
+  const keys2 = Object.keys(obj2);
+
+  // 키 수 비교
+  if (keys1.length !== keys2.length) {
+    return false;
+  }
+
+  // 모든 키에 대해 재귀적으로 비교
+  for (const key of keys1) {
+    if (!keys2.includes(key) || !deepEqual(obj1[key], obj2[key])) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/utils/test/compare.test.ts
+++ b/src/utils/test/compare.test.ts
@@ -1,0 +1,41 @@
+import { deepEqual } from "../compare";
+
+describe("deepEqual", () => {
+  it("같은 객체는 true를 반환해야 함", () => {
+    const obj = { a: 1, b: { c: 2 } };
+    expect(deepEqual(obj, obj)).toBe(true);
+  });
+
+  it("객체의 값이 동일한 경우 true를 반환해야 함", () => {
+    const obj1 = { a: 1, b: { c: 2 } };
+    const obj2 = { a: 1, b: { c: 2 } };
+
+    const obj3 = { a: { a1: 1, a2: 2, a3: 3, a4: 4 }, b: { c: 2 } };
+    const obj4 = { a: { a1: 1, a2: 2, a3: 3, a4: 4 }, b: { c: 2 } };
+
+    expect(deepEqual(obj1, obj2)).toBe(true);
+    expect(deepEqual(obj3, obj4)).toBe(true);
+  });
+
+  it("객체의 값이 다를 경우 false를 반환해야 함", () => {
+    const obj1 = { a: 1, b: { c: 2 } };
+    const obj2 = { a: 1, b: { c: 3 } };
+
+    const obj3 = { a: { a1: 1, a2: 2, a3: 3, a4: 4 }, b: { c: 2 } };
+    const obj4 = { a: { a1: 1, a2: 2, a3: 3, a4: 5 }, b: { c: 2 } };
+
+    expect(deepEqual(obj1, obj2)).toBe(false);
+    expect(deepEqual(obj3, obj4)).toBe(false);
+  });
+
+  it("다른 타입을 비교할 경우 false를 반환해야 함", () => {
+    const obj = { a: 1, b: { c: 2 } };
+    expect(deepEqual(obj, "not an object")).toBe(false);
+  });
+
+  it("키가 누락된 경우 false를 반환해야 함", () => {
+    const obj1 = { a: 1, b: 2 };
+    const obj2 = { a: 1 };
+    expect(deepEqual(obj1, obj2)).toBe(false);
+  });
+});


### PR DESCRIPTION
- 성능적인 면을 고려하여 JSON.stringify 대신 객체를 비교하는 deepEqual 함수를 만들었습니다.  

- test 코드를 추가 & 아래 오픈소스들을 참고하여 성능을 더 개선해보려고 합니다.  

- [오픈소스](https://npmtrends.com/deep-equal-vs-fast-deep-equal-vs-fast-json-stable-stringify-vs-lodash.isequal)